### PR TITLE
Fix for python3.9 support

### DIFF
--- a/dataclasses_serialization/__init__.py
+++ b/dataclasses_serialization/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.3.1"
+__version__ = "1.3.1.fbx.fix"

--- a/dataclasses_serialization/serializer_base/typing.py
+++ b/dataclasses_serialization/serializer_base/typing.py
@@ -8,9 +8,9 @@ from typing_inspect import get_args, get_generic_bases, get_origin
 try:
     from typing import GenericMeta
 except ImportError:
-    from typing import _GenericAlias, _SpecialForm
+    from typing import _GenericAlias, _SpecialForm, _SpecialGenericAlias
 
-    GenericMeta = (_GenericAlias, _SpecialForm)
+    GenericMeta = (_GenericAlias, _SpecialForm, _SpecialGenericAlias)
 
 __all__ = [
     "isinstance",


### PR DESCRIPTION
add _SpecialGenericAlias to GenericMeta to support typing.Dict and typing.List

`type(typing.Dict)` and `type(typing.List)` return `_SpecialGenericAlias`  in python3.9 (compared to `_GenericAlias` in python<=3.8)
Need to add it to `GenericMeta` so that `if original_isinstance(cls, GenericMeta):` can catch it (dataclasses_serialization/serializer_base/typing.py:64)